### PR TITLE
chore(docker): install dependencies from uv lockfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM python:3.11
 
 ENV TZ=Asia/Shanghai
-
-COPY requirements.txt /src/
+ENV PATH="/src/.venv/bin:$PATH"
 
 WORKDIR /src
-RUN pip install -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements.txt
+COPY pyproject.toml uv.lock /src/
+RUN pip install -i https://pypi.tuna.tsinghua.edu.cn/simple uv \
+    && uv sync --frozen --no-dev --no-install-project
 
 COPY . .
 


### PR DESCRIPTION
Summary:
- Update Dockerfile to install uv and sync dependencies from uv.lock.
- Put the project virtualenv on PATH so container runtime uses the locked environment.

Tests:
- uv sync --frozen
- Ran test/test_api_decorator_chain.py with external _321CQU available on PYTHONPATH: 5 passed

Stack:
- Depends on #13.