### PR TITLE
fix(errors): redact sensitive request data in logs

### DIFF
--- a/utils/Exceptions.py
+++ b/utils/Exceptions.py
@@ -1,9 +1,44 @@
+import json as json_lib
 from typing import Optional, Union, Dict, Any
 
 from sanic.exceptions import SanicException
 from sanic.handlers import ErrorHandler
 from sanic.log import error_logger
 from sanic.response import json
+
+
+_SENSITIVE_KEYS = {
+    "token",
+    "authorization",
+    "apikey",
+    "api_key",
+    "refresh_token",
+    "refreshtoken",
+    "password",
+}
+_REDACTED_VALUE = "<redacted>"
+
+
+def _redact_sensitive_data(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: (_REDACTED_VALUE if str(key).lower() in _SENSITIVE_KEYS else _redact_sensitive_data(item))
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_sensitive_data(item) for item in value]
+    return value
+
+
+def _redact_request_body(body: bytes) -> str:
+    if not body:
+        return ""
+
+    body_text = body.decode(errors="replace")
+    try:
+        return json_lib.dumps(_redact_sensitive_data(json_lib.loads(body_text)), ensure_ascii=False)
+    except json_lib.JSONDecodeError:
+        return _REDACTED_VALUE
 
 
 class _321CQUException(SanicException):
@@ -21,6 +56,8 @@ class _321CQUException(SanicException):
     ) -> None:
         super().__init__(message, status_code, quiet=quite, context=context, extra=extra)
         self.error_info = error_info if error_info is not None else ""
+        if quite is not None:
+            self.quite = quite
 
 
 class _321CQUErrorHandler(ErrorHandler):
@@ -28,10 +65,10 @@ class _321CQUErrorHandler(ErrorHandler):
         if isinstance(exception, _321CQUException):
             self.log(request, exception)
             if not exception.quite:
-                error_logger.exception(f"request token is {request.token}, request param is {request.body.decode()}")
+                error_logger.exception(
+                    f"request token is {_REDACTED_VALUE}, request param is {_redact_request_body(request.body)}"
+                )
             return json({'status': 0, 'msg': exception.error_info, 'data': exception.context},
                         status=exception.status_code)
         else:
             return super().default(request, exception)
-
-


### PR DESCRIPTION
Summary:
- Redact request token in noisy error logs.
- Redact sensitive JSON body fields such as token, apiKey, password, and refreshToken.
- Ensure _321CQUException(quite=False) updates the instance flag so logging behavior matches caller intent.

Tests:
- uv sync --frozen
- Ran test/test_api_decorator_chain.py with external _321CQU available on PYTHONPATH: 5 passed

Notes:
- Existing login/notification tests still fail because current test fixture setup does not inject _321CQU.tools.ConfigHandler for MockGRPCManager, and package-scoped app reuse causes duplicate dynamic routes. This is pre-existing test infrastructure behavior, not introduced by this branch.