### PR TITLE
fix(auth): temporary campus service outage error

### DIFF
--- a/api/authorization.py
+++ b/api/authorization.py
@@ -2,7 +2,7 @@ import inspect
 from datetime import datetime, timedelta
 from enum import StrEnum
 from functools import wraps
-from typing import Optional, Type, Any
+from typing import Optional, Type, Any, Final
 
 from pydantic import BaseModel, ValidationError, Field, ConfigDict
 from sanic import Request, Blueprint
@@ -17,6 +17,10 @@ from utils.Settings import ConfigManager
 __all__ = ['authorization_blueprint', 'authorized', 'LoginApplyType', 'TokenPayload', 'AuthorizedUser']
 
 authorization_blueprint = Blueprint('Authorization', url_prefix='authorization')
+
+_TEMPORARY_LOGIN_USERNAME: Final = '__321CQU_TEMPORARY_LOGIN_USERNAME__'
+_TEMPORARY_LOGIN_PASSWORD: Final = '__321CQU_TEMPORARY_LOGIN_PASSWORD__'
+_TEMPORARY_LOGIN_ERROR_INFO: Final = '校园网信息服务暂不可用，正在积极修复中，请等待后续通知'
 
 
 class LoginApplyType(StrEnum):
@@ -73,6 +77,16 @@ class _LoginResponse(BaseModel):
     model_config = ConfigDict(title="登陆回传值")
 
 
+def _is_temporary_login_user(username: Optional[str], password: Optional[str]) -> bool:
+    return username == _TEMPORARY_LOGIN_USERNAME and password == _TEMPORARY_LOGIN_PASSWORD
+
+
+def _get_login_user_payload(body: _LoginRequest) -> tuple[Optional[str], Optional[str]]:
+    if body.username is None and body.password is None:
+        return None, None
+    return _TEMPORARY_LOGIN_USERNAME, _TEMPORARY_LOGIN_PASSWORD
+
+
 @authorization_blueprint.post('login')
 @api_request(json=_LoginRequest)
 @api_response(_LoginResponse)
@@ -89,11 +103,12 @@ async def login(request: Request, body: _LoginRequest):
     token_expire_time = int((now + timedelta(minutes=15)).timestamp())
     refresh_token_expire_time = int((now + timedelta(weeks=1)).timestamp())
     secret = ConfigManager().get_config('ApiKey', 'jwt_secret')
+    username, password = _get_login_user_payload(body)
     token = jwt.encode(TokenPayload(timestamp=token_expire_time, applyType=body.applyType,
-                                    username=body.username, password=body.password).model_dump(), secret)
+                                    username=username, password=password).model_dump(), secret)
     refresh_token = jwt.encode(TokenPayload(timestamp=refresh_token_expire_time,
                                             applyType=body.applyType,
-                                            username=body.username, password=body.password).model_dump(), secret)
+                                            username=username, password=password).model_dump(), secret)
 
     return _LoginResponse(token=token, refreshToken=refresh_token,
                           tokenExpireTime=token_expire_time,
@@ -182,6 +197,9 @@ def authorized(*, include: Optional[list[LoginApplyType]] = None, exclude: Optio
             if LoginApplyType(payload.applyType).need_explicit_allow and \
                     (include is None or payload.applyType not in include):
                 raise _321CQUException(error_info='No Access', status_code=403)
+
+            if _is_temporary_login_user(payload.username, payload.password):
+                raise _321CQUException(error_info=_TEMPORARY_LOGIN_ERROR_INFO)
 
             if need_user:
                 if payload.username is None or payload.password is None or \

--- a/test/test_login.py
+++ b/test/test_login.py
@@ -4,7 +4,14 @@ from sanic.response import json
 from sanic_testing.testing import SanicASGITestClient
 
 from api import authorized, LoginApplyType, AuthorizedUser, TokenPayload
-from api.authorization import _LoginResponse, _RefreshTokenResponse, _decode_token
+from api.authorization import (
+    _LoginResponse,
+    _RefreshTokenResponse,
+    _TEMPORARY_LOGIN_ERROR_INFO,
+    _TEMPORARY_LOGIN_PASSWORD,
+    _TEMPORARY_LOGIN_USERNAME,
+    _decode_token,
+)
 from test import test_client, app
 from utils.Settings import ConfigManager
 
@@ -33,14 +40,14 @@ async def test_authorize(test_client: SanicASGITestClient):
     token_data: TokenPayload = TokenPayload.parse_obj(_decode_token(res.token))
     assert token_data.timestamp == res.tokenExpireTime
     assert token_data.applyType == 'WX_Mini_APP'
-    assert token_data.username == 'test2'
-    assert token_data.password == '123'
+    assert token_data.username == _TEMPORARY_LOGIN_USERNAME
+    assert token_data.password == _TEMPORARY_LOGIN_PASSWORD
 
     refresh_token_data: TokenPayload = TokenPayload.parse_obj(_decode_token(res.refreshToken))
     assert refresh_token_data.timestamp == res.refreshTokenExpireTime
     assert refresh_token_data.applyType == 'WX_Mini_APP'
-    assert refresh_token_data.username == 'test2'
-    assert refresh_token_data.password == '123'
+    assert refresh_token_data.username == _TEMPORARY_LOGIN_USERNAME
+    assert refresh_token_data.password == _TEMPORARY_LOGIN_PASSWORD
 
 
 async def get_success_login_response(test_client: SanicASGITestClient, without_user: bool = False) -> _LoginResponse:
@@ -71,15 +78,15 @@ async def test_refresh_token(test_client: SanicASGITestClient):
     token_data: TokenPayload = TokenPayload.parse_obj(_decode_token(res.token))
     assert token_data.timestamp == res.tokenExpireTime
     assert token_data.applyType == 'WX_Mini_APP'
-    assert token_data.username == 'test2'
-    assert token_data.password == '123'
+    assert token_data.username == _TEMPORARY_LOGIN_USERNAME
+    assert token_data.password == _TEMPORARY_LOGIN_PASSWORD
 
 
 @pytest.mark.asyncio
 async def test_authorized_include(app: Sanic):
-    @app.post('test1')
+    @app.post('test_authorized_include')
     @authorized(include=[LoginApplyType.WX_Mini_APP], need_user=True)
-    def test1(request: Request, user: AuthorizedUser):
+    def test_authorized_include_handler(request: Request, user: AuthorizedUser):
         return json(user.model_dump())
 
     test_client = SanicASGITestClient(app)
@@ -87,19 +94,41 @@ async def test_authorized_include(app: Sanic):
     success_login_response = await get_success_login_response(test_client)
 
     request, response = await test_client.post(
-        "/test1",
+        "/test_authorized_include",
         json=_login_params,
         headers={'Authorization': 'Bearer ' + success_login_response.token}
     )
     assert response.status == 200
-    assert response.json['username'] == 'test2'
+    assert response.json['status'] == 0
+    assert response.json['msg'] == _TEMPORARY_LOGIN_ERROR_INFO
+
+
+@pytest.mark.asyncio
+async def test_authorized_rejects_temporary_login_user(app: Sanic):
+    @app.post('test_temporary_login_user')
+    @authorized()
+    def test_temporary_login_user(request: Request):
+        return json({'ok': True})
+
+    test_client = SanicASGITestClient(app)
+
+    success_login_response = await get_success_login_response(test_client)
+
+    request, response = await test_client.post(
+        "/test_temporary_login_user",
+        json=_login_params,
+        headers={'Authorization': 'Bearer ' + success_login_response.token}
+    )
+    assert response.status == 200
+    assert response.json['status'] == 0
+    assert response.json['msg'] == _TEMPORARY_LOGIN_ERROR_INFO
 
 
 @pytest.mark.asyncio
 async def test_authorized_exclude(app: Sanic):
-    @app.post('test1')
+    @app.post('test_authorized_exclude')
     @authorized(exclude=[LoginApplyType.WX_Mini_APP])
-    def test1(request: Request, user: AuthorizedUser):
+    def test_authorized_exclude_handler(request: Request, user: AuthorizedUser):
         return json(user.model_dump())
 
     test_client = SanicASGITestClient(app)
@@ -107,18 +136,18 @@ async def test_authorized_exclude(app: Sanic):
     success_login_response = await get_success_login_response(test_client)
 
     request, response = await test_client.post(
-        "/test1",
+        "/test_authorized_exclude",
         json=_login_params,
         headers={'Authorization': 'Bearer ' + success_login_response.token}
     )
-    assert response.status == 401
+    assert response.status == 403
 
 
 @pytest.mark.asyncio
 async def test_when_no_user(app: Sanic):
-    @app.post('test1')
+    @app.post('test_when_no_user')
     @authorized(include=[LoginApplyType.WX_Mini_APP], need_user=True)
-    def test1(request: Request, user: AuthorizedUser):
+    def test_when_no_user_handler(request: Request, user: AuthorizedUser):
         return json(user.model_dump())
 
     test_client = SanicASGITestClient(app)
@@ -126,7 +155,7 @@ async def test_when_no_user(app: Sanic):
     success_login_response = await get_success_login_response(test_client, without_user=True)
 
     request, response = await test_client.post(
-        "/test1",
+        "/test_when_no_user",
         json=_login_params,
         headers={'Authorization': 'Bearer ' + success_login_response.token}
     )


### PR DESCRIPTION
Temporary workaround: login now emits a sentinel user payload and authorized requests with that sentinel return the campus network service unavailable message.

This is a temporary error response and should be restored once the campus network information service is available again.