### PR TITLE
fix(auth): limit temporary outage error to user endpoints

### DIFF
--- a/api/authorization.py
+++ b/api/authorization.py
@@ -198,10 +198,9 @@ def authorized(*, include: Optional[list[LoginApplyType]] = None, exclude: Optio
                     (include is None or payload.applyType not in include):
                 raise _321CQUException(error_info='No Access', status_code=403)
 
-            if _is_temporary_login_user(payload.username, payload.password):
-                raise _321CQUException(error_info=_TEMPORARY_LOGIN_ERROR_INFO)
-
             if need_user:
+                if _is_temporary_login_user(payload.username, payload.password):
+                    raise _321CQUException(error_info=_TEMPORARY_LOGIN_ERROR_INFO)
                 if payload.username is None or payload.password is None or \
                         payload.username == '' or payload.password == '':
                     raise _321CQUException(error_info='User Info Not Found', status_code=401)

--- a/test/test_login.py
+++ b/test/test_login.py
@@ -104,7 +104,7 @@ async def test_authorized_include(app: Sanic):
 
 
 @pytest.mark.asyncio
-async def test_authorized_rejects_temporary_login_user(app: Sanic):
+async def test_authorized_allows_temporary_login_user_without_need_user(app: Sanic):
     @app.post('test_temporary_login_user')
     @authorized()
     def test_temporary_login_user(request: Request):
@@ -120,8 +120,7 @@ async def test_authorized_rejects_temporary_login_user(app: Sanic):
         headers={'Authorization': 'Bearer ' + success_login_response.token}
     )
     assert response.status == 200
-    assert response.json['status'] == 0
-    assert response.json['msg'] == _TEMPORARY_LOGIN_ERROR_INFO
+    assert response.json == {'ok': True}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Temporary change: only endpoints requiring user credentials return the campus network service unavailable message for sentinel login tokens. Token-only endpoints continue to pass through.

This temporary behavior should be restored when the campus network information service is available again.