### PR TITLE
fix(auth): temporarily default validateAuth response

### DIFF
--- a/api/authorization.py
+++ b/api/authorization.py
@@ -170,15 +170,20 @@ class AuthorizedUser(BaseModel):
 
     model_config = ConfigDict(title="经验证的用户")
 
+    @property
+    def is_temporary_login(self) -> bool:
+        return _is_temporary_login_user(self.username, self.password)
+
 
 def authorized(*, include: Optional[list[LoginApplyType]] = None, exclude: Optional[list[LoginApplyType]] = None,
-               need_user: bool = False, user_argument: str = 'user'):
+               need_user: bool = False, user_argument: str = 'user', allow_temporary_user: bool = False):
     """
     api权限校验装饰器
     :param include: 可以使用该api的权限请求方式
     :param exclude: 无法使用该api权限的请求方式
     :param need_user: 需要从token中获取用户
     :param user_argument: 注入到参数中的变量名称
+    :param allow_temporary_user: 是否允许临时登录用户继续进入handler
     """
     if include and exclude:
         raise InitError("Cannot set include and exclude at same time")
@@ -199,7 +204,7 @@ def authorized(*, include: Optional[list[LoginApplyType]] = None, exclude: Optio
                 raise _321CQUException(error_info='No Access', status_code=403)
 
             if need_user:
-                if _is_temporary_login_user(payload.username, payload.password):
+                if _is_temporary_login_user(payload.username, payload.password) and not allow_temporary_user:
                     raise _321CQUException(error_info=_TEMPORARY_LOGIN_ERROR_INFO)
                 if payload.username is None or payload.password is None or \
                         payload.username == '' or payload.password == '':

--- a/api/edu_admin_center.py
+++ b/api/edu_admin_center.py
@@ -34,12 +34,15 @@ class _ValidateAuthResponse(BaseModel):
 @edu_admin_center_blueprint.post(uri='validateAuth')
 @api_request()
 @api_response(_ValidateAuthResponse)
-@authorized(need_user=True)
+@authorized(need_user=True, allow_temporary_user=True)
 @handle_grpc_error
 async def validate_auth(request: Request, user: AuthorizedUser, grpc_manager: gRPCManager):
     """
     账号验证
     """
+    if user.is_temporary_login:
+        return _ValidateAuthResponse(sid='', auth='', name='', uid='')
+
     async with grpc_manager.get_stub(ServiceEnum.EduAdminCenter) as stub:
         stub: eac_grpc.EduAdminCenterStub = stub
         res: eac_models.ValidateAuthResponse = await stub.ValidateAuth(

--- a/test/test_login.py
+++ b/test/test_login.py
@@ -104,6 +104,23 @@ async def test_authorized_include(app: Sanic):
 
 
 @pytest.mark.asyncio
+async def test_validate_auth_allows_temporary_login_user(test_client: SanicASGITestClient):
+    success_login_response = await get_success_login_response(test_client)
+
+    request, response = await test_client.post(
+        "/v1/edu_admin_center/validateAuth",
+        headers={'Authorization': 'Bearer ' + success_login_response.token}
+    )
+
+    assert response.status == 200
+    assert response.json == {
+        'status': 1,
+        'msg': 'success',
+        'data': {'sid': '', 'auth': '', 'name': '', 'uid': ''},
+    }
+
+
+@pytest.mark.asyncio
 async def test_authorized_allows_temporary_login_user_without_need_user(app: Sanic):
     @app.post('test_temporary_login_user')
     @authorized()


### PR DESCRIPTION
Temporary change: allow sentinel login tokens through validateAuth and return an empty default auth payload instead of calling the campus network service.

This should be restored when the campus network information service is available again.