### PR TITLE
fix(auth): use placeholder validateAuth response

### DIFF
--- a/api/edu_admin_center.py
+++ b/api/edu_admin_center.py
@@ -31,6 +31,14 @@ class _ValidateAuthResponse(BaseModel):
     model_config = ConfigDict(title="验证账号回传值")
 
 
+_TEMPORARY_VALIDATE_AUTH_RESPONSE = _ValidateAuthResponse(
+    sid='00000000',
+    auth='00000000',
+    name='临时用户',
+    uid='00000000000000000000000000000000',
+)
+
+
 @edu_admin_center_blueprint.post(uri='validateAuth')
 @api_request()
 @api_response(_ValidateAuthResponse)
@@ -41,7 +49,7 @@ async def validate_auth(request: Request, user: AuthorizedUser, grpc_manager: gR
     账号验证
     """
     if user.is_temporary_login:
-        return _ValidateAuthResponse(sid='', auth='', name='', uid='')
+        return _TEMPORARY_VALIDATE_AUTH_RESPONSE
 
     async with grpc_manager.get_stub(ServiceEnum.EduAdminCenter) as stub:
         stub: eac_grpc.EduAdminCenterStub = stub

--- a/test/test_login.py
+++ b/test/test_login.py
@@ -116,7 +116,12 @@ async def test_validate_auth_allows_temporary_login_user(test_client: SanicASGIT
     assert response.json == {
         'status': 1,
         'msg': 'success',
-        'data': {'sid': '', 'auth': '', 'name': '', 'uid': ''},
+        'data': {
+            'sid': '00000000',
+            'auth': '00000000',
+            'name': '临时用户',
+            'uid': '00000000000000000000000000000000',
+        },
     }
 
 


### PR DESCRIPTION
Temporary change: return stable non-empty placeholder values for sentinel validateAuth responses instead of empty strings.

This should be restored when the campus network information service is available again.